### PR TITLE
Chore: Update link text in hero section to "Instaq"

### DIFF
--- a/components/hero-section.vue
+++ b/components/hero-section.vue
@@ -193,7 +193,7 @@ const stacks: Array<{ icon: string; name: string }> = [
         <NuxtLink
           class="text-[#11FAC0] min-w-fit border-b-2 border-dashed border-spacing-4 border-ntl-0/40 hover:active:border-ntl-0/80 hover:active:text-[#5EFA11] transition-colors duration-200 ease-in"
           to="https://instituto.taqtile.com.br">
-          Taqtile Institute
+          Instaq
           <span class="text-current animate-[pulse_1500ms_infinite] font-bold">|</span>
         </NuxtLink>
       </div>


### PR DESCRIPTION
Change the link text in the hero section from "Taqtile Institute" to "Instaq."